### PR TITLE
Condense settings page layout into tabs

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "url": "https://github.com/fabian-peters/"
   },
   "contributors": [
-    "RonanRU"
+    "RonanRU",
+    "jayeclark"
   ],
   "scripts": {
     "build": "tsc",

--- a/resources/index.html
+++ b/resources/index.html
@@ -6,111 +6,156 @@
     <link rel="stylesheet" href='style.css' />
   </head>
   <body>
-    <form id="settings" style="display: none">
-      <button type="button" id="backButton">Back</button>
-      <hr style='width: 80%'>
-      <h1>Settings</h1>
-      <h2>General</h2>
-      <div>
-        <label for="streamLabsTokenInput" title="One or more Socket API tokens (comma-separated) to receive subscription info.">Streamlabs Tokens</label>
-        <textarea id="streamLabsTokenInput"></textarea>
+    <form id="settings" style="display: none;">
+      <div class="w-full relative">
+        <div class="settings-title">Settings</div>
+        <div class="absolute" id="backButtonContainer"><button type="button" id="backButton">Back</button></div>
       </div>
       <div>
-        <label for="portInput" title="The port on which to listen for connections.">Port</label>
-        <input type="text" accept="[0-9]+" id="portInput" />
+        <!-- NAVIGATION -->
+        <div class="nav-tabs">
+          <ul class="nav">
+            <li class="nav-item active" id="general-nav" onclick="showSection(id)">
+              <div class="m-auto">General</div>
+            </li>
+            <li class="nav-item" id="timer-nav" onclick="showSection(id)">
+              <div class="m-auto">Timer</div>
+            </li>
+            <li class="nav-item" id="timer-history-nav" onclick="showSection(id)">
+              <div class="m-auto">Timer<br>History</div>
+            </li>
+            <li class="nav-item" id="sub-history-nav" onclick="showSection(id)">
+              <div class="m-auto">Sub<br>History</div>
+            </li>
+            <li class="nav-item" id="colors-nav" onclick="showSection(id)">
+              <div class="m-auto">Colors</div>
+            </li>
+            <li class="nav-item" id="webhooks-nav" onclick="showSection(id)">
+              <div class="m-auto">Webhooks</div>
+            </li>
+          </ul>
+        </div>
+        <!--- GENERAL FIELDS-->
+        <div id="general" class="settings-section">
+          <div class="input-lockup flex-wrap">
+            <label class="w-full" for="streamLabsTokenInput" class="w-100" title="One or more Socket API tokens (comma-separated) to receive subscription info.">
+              Streamlabs Tokens
+            </label>
+            <textarea class="w-full" id="streamLabsTokenInput"></textarea>
+          </div>
+          <div class="input-lockup">
+            <label for="portInput" title="The port on which to listen for connections.">Port</label>
+            <input type="text" accept="[0-9]+" id="portInput" />
+          </div>
+          <div class="input-lockup">
+            <div class="colorInputContainer">
+              <label for="timerHistoryEnabledInput" title='Determines whether the timer history will be saved to the history.json file.'>Save Timer History</label>
+              <input type="checkbox" id="timerHistoryEnabledInput" />
+            </div>
+            <div class="colorInputContainer">
+              <label for="subHistoryEnabledInput" title='Determines whether the subscription history will be saved to the subs.json file.'>Save Sub History</label>
+              <input type="checkbox" id="subHistoryEnabledInput" />
+            </div>  
+          </div>
+        </div>
+        <!--- TIMER WIDGET FIELDS-->
+        <div id="timer" class="settings-section hide">
+          <div class="input-lockup">
+            <label for="inTimeInput" title='The initial time at which the timer starts.'>Initial Timer (mins)</label>
+            <input type="number" id="inTimeInput" />
+          </div>
+          <div class="input-lockup flex-wrap">
+            <div class="label-div w-full">Additional time per sub (secs)</div>
+            <div class="input-lockup flex-wrap w-33">
+              <label class="w-full font-sm my-0" for="addTimeTier1Input" title='The additional time that gets added to the timer for a Tier 1 or Prime subscription.'>Tier 1</label>
+              <input class="w-full" type="number" id="addTimeTier1Input" />
+            </div>
+            <div class="input-lockup flex-wrap w-33">
+              <label class="w-full font-sm my-0"  for="addTimeTier2Input" title='The additional time that gets added to the timer for a Tier 2 subscription.'>Tier 2</label>
+              <input class="w-full" type="number" id="addTimeTier2Input" />
+            </div>
+            <div class="input-lockup flex-wrap w-33">
+              <label class="w-full font-sm my-0"  for="addTimeTier3Input" title='The additional time that gets added to the timer for a Tier 3 subscription.'>Tier 3</label>
+              <input class="w-full" type="number" id="addTimeTier3Input" />
+            </div>  
+          </div>
+          <div class="input-lockup">
+            <label for="timespanInput" title='The timespan how far back the graph shows the time, e.g. 120 means the graph shows the time in the past 2 minutes.'>Graph Timespan (seconds)</label>
+            <input type="number" id="timespanInput" />
+          </div>
+          <div class="input-lockup">
+            <label for="refreshIntervalInput" title='How often the graph gets refreshed, e.g. 10 means the graph is refreshed every 10s.'>Graph Refresh (seconds)</label>
+            <input type="number" id="refreshIntervalInput" />
+          </div>
+        </div>
+        <!--- TIMER HISTORY FIELDS-->
+        <div id="timer-history" class="settings-section hide">
+          <div class="input-lockup">
+            <label for="timerHistoryIntervalInput" title='How often the current time is saved to the history.json file, e.g. 60 means the file is updated once every minute.'>Interval (secs)</label>
+            <input type="number" id="timerHistoryIntervalInput" />
+          </div>
+          <div class="colorInputContainer w-full">
+            <label class="w-170px min-w-170px" for="timerHistoryShowTotalInput" title='Show or hide the total time in the history widget.'>Show Total Time</label>
+            <input type="checkbox" id="timerHistoryShowTotalInput" />
+          </div>
+          <div class="button-lockup">
+            <button class="w-auto shrink-1 grow-1 text-nowrap" type="button" id="timerHistoryResetButton" title='Delete the currently stored timer history. You will lose all data in the history.json file.'>Reset Timer History</button>
+            <button class="w-auto shrink-1 grow-1 text-nowrap" type="button" id="timerHistoryExportButton" title='Export the current timer history graph as PNG.'>Export Timer History Graph</button>    
+          </div>
+          </div>
+        <!--- SUB HISTORY FIELDS-->
+        <div id="sub-history" class="settings-section hide">
+          <div class="input-lockup">
+            <label for="subHistoryRefreshInput" title='How often the graph gets refreshed, e.g. 10 means the graph is refreshed every 10s. It is automatically updated when a new sub comes in.'>Refresh (secs)</label>
+            <input type="number" id="subHistoryRefreshInput" />
+          </div>
+          <div class="colorInputContainer">
+            <label class="w-170px min-w-170px" for="subHistoryShowTotalInput" title='Show or hide the total number of new subscriptions in the subs widget.'>Show Total Sub Count</label>
+            <input type="checkbox" id="subHistoryShowTotalInput" />
+          </div>
+          <div class="button-lockup">
+            <button class="w-auto shrink-1 grow-1 text-nowrap" type="button" id="subHistoryResetButton" title='Delete the currently stored subscription history. You will lose all data in the subs.json file.'>Reset Sub History</button>
+            <button class="w-auto shrink-1 grow-1 text-nowrap" type="button" id="subHistoryExportButton" title='Export the current subscription history graph as PNG.'>Export Sub History Graph</button>    
+          </div>
+        </div>
+        <!--- COLORS FIELDS-->
+        <div id="colors" class="settings-section hide">
+            <div class="colorInputContainer w-full justify-center">
+              <label class="min-w-50" for="bgColorInput" title='The color of the background.'>Background Color</label>
+              <input class="color-picker"  type="color" id="bgColorInput" />
+            </div>
+            <div class="colorInputContainer w-full justify-center">
+              <label class="min-w-50"  for="timerColorInput" title='The color of the timer/sub count.'>Timer Color</label>
+              <input class="color-picker"  type="color" id="timerColorInput" />
+            </div>
+            <div class="colorInputContainer w-full justify-center">
+              <label class="min-w-50"  for="lineColorInput" title='The color of the line graph.'>Line Color</label>
+              <input class="color-picker" type="color" id="lineColorInput" />
+            </div>
+            <div class="colorInputContainer w-full justify-center">
+              <label class="min-w-50"  for="timerShadowColorInput" title='The color of the shadow/glow of the timer/sub count. Use the same color as the background to disable.'>Timer Shadow Color</label>
+              <input class="color-picker" type="color" id="timerShadowColorInput" />
+            </div>  
+        </div>
+        <!-- WEBHOOKS FIELDS-->
+        <div id="webhooks" class="settings-section hide">
+          <div class="colorInputContainer">
+            <label class="w-170px min-w-170px" for="webhookEnabledInput" title='Enable or disable triggering the configured webhook.'>Enable Timer Webhook</label>
+            <input type="checkbox" id="webhookEnabledInput" />
+          </div>
+          <div class="input-lockup flex-wrap">
+            <label class="w-full" for="webhookUrlInput" title='The URL of the webhook to call.'>Webhook URL</label>
+            <input class="w-full" type="text" id="webhookUrlInput" />
+          </div>
+          <div class="input-lockup">
+            <label for="webhookTriggerInput" title='The time at which the webhook should be triggered.'>Webhook Trigger Time</label>
+            <input type="time" step="1" id="webhookTriggerInput" />
+          </div>
+        </div>
+        <div class="form-submission">
+          <button type="submit">Submit</button>
+        </div>
       </div>
-      <h2>Timer Widget</h2>
-      <div>
-        <label for="inTimeInput" title='The initial time at which the timer starts.'>Initial Time (minutes)</label>
-        <input type="number" id="inTimeInput" />
-      </div>
-      <hr style='width: 35%'>
-      <div>
-        <label for="addTimeTier1Input" title='The additional time that gets added to the timer for a Tier 1 or Prime subscription.'>Additional Time Tier 1 (seconds)</label>
-        <input type="number" id="addTimeTier1Input" />
-      </div>
-      <div>
-        <label for="addTimeTier2Input" title='The additional time that gets added to the timer for a Tier 2 subscription.'>Additional Time Tier 2 (seconds)</label>
-        <input type="number" id="addTimeTier2Input" />
-      </div>
-      <div>
-        <label for="addTimeTier3Input" title='The additional time that gets added to the timer for a Tier 3 subscription.'>Additional Time Tier 3 (seconds)</label>
-        <input type="number" id="addTimeTier3Input" />
-      </div>
-      <hr style='width: 35%'>
-      <div>
-        <label for="timespanInput" title='The timespan how far back the graph shows the time, e.g. 120 means the graph shows the time in the past 2 minutes.'>Graph Timespan (seconds)</label>
-        <input type="number" id="timespanInput" />
-      </div>
-      <div>
-        <label for="refreshIntervalInput" title='How often the graph gets refreshed, e.g. 10 means the graph is refreshed every 10s.'>Graph Refresh (seconds)</label>
-        <input type="number" id="refreshIntervalInput" />
-      </div>
-      <hr style='width: 35%'>
-      <div class="colorInputContainer">
-        <label for="timerHistoryEnabledInput" title='Determines whether the timer history will be saved to the history.json file.'>Save Timer History</label>
-        <input type="checkbox" id="timerHistoryEnabledInput" />
-      </div>
-      <div>
-        <label for="timerHistoryIntervalInput" title='How often the current time is saved to the history.json file, e.g. 60 means the file is updated once every minute.'>Timer History Interval (seconds)</label>
-        <input type="number" id="timerHistoryIntervalInput" />
-      </div>
-      <div class="colorInputContainer">
-        <label for="subHistoryEnabledInput" title='Determines whether the subscription history will be saved to the subs.json file.'>Save Sub History</label>
-        <input type="checkbox" id="subHistoryEnabledInput" />
-      </div>
-      <h2>Timer History Widget</h2>
-      <div class="colorInputContainer">
-        <label for="timerHistoryShowTotalInput" title='Show or hide the total time in the history widget.'>Show Total Time</label>
-        <input type="checkbox" id="timerHistoryShowTotalInput" />
-      </div>
-      <hr style='width: 35%'>
-      <button type="button" id="timerHistoryResetButton" title='Delete the currently stored timer history. You will lose all data in the history.json file.'>Reset Timer History</button>
-      <button type="button" id="timerHistoryExportButton" title='Export the current timer history graph as PNG.'>Export Timer History Graph</button>
-      <h2>Sub History Widget</h2>
-      <div class="colorInputContainer">
-        <label for="subHistoryShowTotalInput" title='Show or hide the total number of new subscriptions in the subs widget.'>Show Total Sub Count</label>
-        <input type="checkbox" id="subHistoryShowTotalInput" />
-      </div>
-      <div>
-        <label for="subHistoryRefreshInput" title='How often the graph gets refreshed, e.g. 10 means the graph is refreshed every 10s. It is automatically updated when a new sub comes in.'>Sub History Refresh (seconds)</label>
-        <input type="number" id="subHistoryRefreshInput" />
-      </div>
-      <hr style='width: 35%'>
-      <button type="button" id="subHistoryResetButton" title='Delete the currently stored subscription history. You will lose all data in the subs.json file.'>Reset Sub History</button>
-      <button type="button" id="subHistoryExportButton" title='Export the current subscription history graph as PNG.'>Export Sub History Graph</button>
-      <h2>Colors (All Widgets)</h2>
-      <div class="colorInputContainer">
-        <label for="bgColorInput" title='The color of the background.'>Background Color</label>
-        <input type="color" id="bgColorInput" />
-      </div>
-      <div class="colorInputContainer">
-        <label for="lineColorInput" title='The color of the line graph.'>Line Color</label>
-        <input type="color" id="lineColorInput" />
-      </div>
-      <div class="colorInputContainer">
-        <label for="timerColorInput" title='The color of the timer/sub count.'>Timer Color</label>
-        <input type="color" id="timerColorInput" />
-      </div>
-      <div class="colorInputContainer">
-        <label for="timerShadowColorInput" title='The color of the shadow/glow of the timer/sub count. Use the same color as the background to disable.'>Timer Shadow Color</label>
-        <input type="color" id="timerShadowColorInput" />
-      </div>
-      <h2>Webhooks</h2>
-      <div class="colorInputContainer">
-        <label for="webhookEnabledInput" title='Enable or disable triggering the configured webhook.'>Enable Timer Webhook</label>
-        <input type="checkbox" id="webhookEnabledInput" />
-      </div>
-      <div>
-        <label for="webhookUrlInput" title='The URL of the webhook to call.'>Webhook URL</label>
-        <input type="text" id="webhookUrlInput" />
-      </div>
-      <div>
-        <label for="webhookTriggerInput" title='The time at which the webhook should be triggered.'>Webhook Trigger Time</label>
-        <input type="time" step="1" id="webhookTriggerInput" />
-      </div>
-      <hr style='width: 80%'>
-      <button type="submit">Submit</button>
     </form>
     <section id="info">
       <div class="controls">
@@ -137,6 +182,22 @@
       <p id='historyStart'></p>
       <p id='subsStart'></p>
     </section>
+    <script>
+      function showSection(id) {
+        const sections = Array.from(document.getElementsByClassName("settings-section"));
+        sections.forEach(div => { 
+          if (!div.classList.contains('hide')) { div.classList.add('hide') }
+        });
+
+        document.getElementById(id.replace('-nav','')).classList.remove('hide');
+
+        const navs = Array.from(document.getElementsByClassName("nav-item"));
+        navs.forEach(nav => {
+          if (nav.classList.contains('active')) { nav.classList.remove('active'); }
+        });
+        document.getElementById(id).classList.add('active');
+      }
+    </script>
     <script src='../dist/script.js'></script>
   </body>
 </html>

--- a/resources/style.css
+++ b/resources/style.css
@@ -24,6 +24,8 @@ body {
 .controls svg:active {
   opacity: 0.5;
 }
+
+/* Settings Page Styles */
 #settings {
   display: flex;
   flex-direction: column;
@@ -35,6 +37,71 @@ body {
   display: flex;
   flex-direction: column;
 }
+.settings-title {
+  font-size: 1.5rem;
+  text-align: center;
+}
+.settings-section {
+  width: 372px;
+  min-height: 200px;
+  margin: 0px -6px 0px -1px;
+  padding: 5px 10px;
+  font-size: 14px;
+  border: 1px solid rgba(155, 155, 155, 1);
+  border-top: none;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
+}
+#backButtonContainer {
+  right: -5px;
+  top: -3px;
+}
+#backButton {
+  margin: 0px 10px;
+  width: fit-content;
+}
+
+/* Settings Navigation Styles */
+.nav-tabs {
+  font-size: 12px;
+  width: 392px;
+}
+ul.nav {
+  list-style-type: none;
+  width: 100%;
+  height: max-content;
+  padding: 0px;
+  margin: 0px;
+  display: flex;
+  justify-content: space-between;
+}
+li.nav-item {
+  flex-grow: 1;
+  display: flex;
+  align-content: center;
+  margin: -1px;
+  width: max-content;
+  padding: 6px 10px;
+  text-align: center;
+  border: 1px solid transparent;
+  border-bottom: 1px solid rgba(155, 155, 155, 1);
+  color: rgba(155, 155, 155, 1);
+  cursor: pointer;
+  border-radius: 6px 6px 0px 0px;
+  font-weight: 600;
+}
+li.nav-item:hover {
+  color: rgba(255, 255, 255, 1);
+}
+.nav-item.active {
+  font-weight: 600;
+  color: rgba(255, 255, 255, 1);
+  border: 1px solid rgba(155, 155, 155, 1);
+  border-bottom: 1px solid transparent;
+}
+
+/* Settings Form Styling */
 input,
 button,
 textarea {
@@ -45,7 +112,7 @@ textarea {
   background: #4d4d4d;
   font-size: 1em;
   outline: none;
-  width: 250px;
+  width: 180px;
   box-sizing: border-box;
 }
 textarea {
@@ -56,12 +123,114 @@ button {
   cursor: pointer;
 }
 .colorInputContainer {
+  flex-wrap: nowrap;
   flex-direction: row !important;
-  justify-content: space-between !important;
-  width: 250px;
+  justify-content: flex-start;
+  align-items: center;
+  width: fit-content;
 }
 .colorInputContainer input {
   padding: 2px;
   width: 30px;
   height: 30px;
+  margin: 5px 10px !important;
+}
+.colorInputContainer .color-picker {
+  max-width: 30px;
+  padding: 0px !important;
+  background-color: transparent;
+}
+.input-lockup {
+  display: flex;
+  flex-direction: row !important;
+  flex-wrap: nowrap;
+  justify-content: space-between;
+  align-items: center;
+}
+.button-lockup {
+  display: flex;
+  flex-direction: row !important;
+  flex-wrap: nowrap;
+  justify-content: space-around;
+  align-items: center;
+}
+.input-lockup input, 
+.input-lockup textarea, 
+.input-lockup label,
+.input-lockup .label-div,
+.colorInputContainer label,
+.button-lockup button {
+  margin: 5px;
+}
+.button-lockup button {
+  padding: 0.5em 1em;
+}
+.form-submission {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  justify-content: center;
+  padding: 10px;
+}
+.form-submission button[type="submit"] {
+  background-color: rgb(40,118,246);
+  cursor: pointer;
+  margin: auto;
+}
+.form-submission button[type="submit"]:hover {
+  background-color: rgb(77, 143, 250);
+}
+
+/* Styling shortcodes */
+.hide {
+  display: none !important;
+}
+.w-full {
+  width: 100%;
+}
+.w-33 {
+  width: 33%;
+}
+.w-auto {
+  width: auto;
+}
+.w-170px {
+  width: 170px;
+}
+.min-w-50 {
+  min-width: 50%;
+}
+.min-w-170px {
+  min-width: 170px;
+}
+.flex-wrap {
+  flex-wrap: wrap;
+}
+.grow-1 {
+  flex-grow: 1;
+}
+.shrink-1 {
+  flex-shrink: 1;
+}
+.justify-center {
+  justify-content: center;
+}
+.text-nowrap {
+  white-space: nowrap;
+}
+.relative {
+  position: relative;
+}
+.absolute {
+  position: absolute;
+}
+.m-auto {
+  margin: auto;
+}
+.my-0 {
+  margin-bottom: 0px !important;
+  margin-top: 0px !important;
+}
+.font-sm {
+  font-size: 0.8em;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,7 +26,7 @@ const createWindow = async () => {
       enableRemoteModule: false,
       nodeIntegration: false
     },
-    width: 420
+    width: 430
   });
   win.removeMenu();
   await win.loadFile(path.join(__dirname, '../resources/index.html'));

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,7 +19,7 @@ let win: BrowserWindow | undefined;
 
 const createWindow = async () => {
   win = new BrowserWindow({
-    height: 380,
+    height: 400,
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),
       contextIsolation: true,

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,14 +19,14 @@ let win: BrowserWindow | undefined;
 
 const createWindow = async () => {
   win = new BrowserWindow({
-    height: 300,
+    height: 380,
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),
       contextIsolation: true,
       enableRemoteModule: false,
       nodeIntegration: false
     },
-    width: 400
+    width: 420
   });
   win.removeMenu();
   await win.loadFile(path.join(__dirname, '../resources/index.html'));


### PR DESCRIPTION
Signed-off-by: Jay Clark <jay@jayeclark.dev>

Hi there @fabian-peters! I came across issue #16 and had some ideas on a possible reorg of the settings form. I still need to clean up the code & styles (particularly the inline styling), and tweak a few minor UI issues, but I thought I'd open a draft PR first to check if this is going in the direction you envisioned and claim the issue if so! (See gif below for UI after alterations)

**_Update 10/11:_** Code has been cleaned up and the discussed changes have been made - I think it looks a lot cleaner! I did have to slightly adjust the size of the control window in order to eliminate the need for settings page scrolling, but it shouldn't affect the other functionality as far as I can tell. I also moved 'save timer history' and 'save sub history' to the general settings page, primarily for layout reasons. 

**Initial Draft (old)**
![SettingsTabs](https://user-images.githubusercontent.com/84106309/141012771-15ab5d4a-5a01-41bd-b5b0-3ad023ef476c.gif)

**IMPROVED VERSION (V2)**
![SettingsTabs-V2](https://user-images.githubusercontent.com/84106309/141142334-867c51df-b4aa-4257-9ec8-29575e73f0f8.gif)


